### PR TITLE
bugfix:#78 - 체크한 상품이 없을 경우 주문 페이지로 이동 블락 처리

### DIFF
--- a/src/components/features/cart/cart.tsx
+++ b/src/components/features/cart/cart.tsx
@@ -61,6 +61,7 @@ export default function Cart() {
       <PriceSummary />
       <div className='w-full sm:w-[60%] mx-auto py-1 rounded-xl'>
         <Button
+          disabled={checkedBooks?.length === 0}
           className='font-semibold text-white-light w-full text-[0.9rem]'
           onClick={handleOnOrder}
         >

--- a/src/components/features/order/order-info.tsx
+++ b/src/components/features/order/order-info.tsx
@@ -23,7 +23,7 @@ export default function OrderInfo() {
     <dl className='w-full flex flex-col items-center'>
       <div className={styles.paymentsField}>
         <dt className={styles.title}>결제금액</dt>
-        <dd className={styles.desc}>{formatNumberWithCommas(totalPrice)}</dd>
+        <dd className={styles.desc}>{formatNumberWithCommas(totalPrice)}원</dd>
       </div>
       <span className={styles.icon}>
         <Plus className='w-full text-gray' />


### PR DESCRIPTION

## 🚀 연관된 이슈

<!-- 해당 PR이 해결하는 이슈 번호를 작성해주세요. (예:  #12) -->

이슈 넘버 : #78 

---

## 📌 작업 내용 요약

<!-- 수행한 작업에 대해 간단히 설명해주세요. -->

- [x] 장바구니 페이지 > 체크한 아이템이 없을 경우 주문하기 버튼 비활성화 처리



---

## ✅ 체크리스트

- [x] 코드에 오류가 없습니다.
- [x] 로컬에서 정상적으로 동작합니다.
- [x] 코드 스타일 가이드에 맞습니다.
- [x] 관련 테스트를 모두 통과했습니다.

---

## 🙏 리뷰어에게 요청사항
